### PR TITLE
FindEGL add 'lib' prefix for native windows

### DIFF
--- a/find-modules/FindEGL.cmake
+++ b/find-modules/FindEGL.cmake
@@ -60,6 +60,7 @@ find_path(EGL_INCLUDE_DIR
 find_library(EGL_LIBRARY
     NAMES
         EGL
+        libEGL 
     HINTS
         ${PKG_EGL_LIBRARY_DIRS}
 )


### PR DESCRIPTION
On a native windows platform EGL libraries (angle) typically come with a lib prefix. 
By default 'CMAKE_FIND_LIBRARY_PREFIX' does not contain 'lib' on native windows so it needs to be added to the search name.